### PR TITLE
Base Docker image on "nextcloudci/node:node-7"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:lts
+FROM nextcloudci/node:node-7
+
+RUN apk add python
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
**Important:** I have not tested _npmbuildbot_ with this new image (I had no idea how to :-P ). Please ensure that I did not break anything :-)

`nextcloudci/node` is used in server and some apps to check whether the JavaScript built files are clean or not. Until recently that Docker image and `node:lts` had the same NPM version, but the version has been recently bumped in `node:lts`, which causes files built with the _npmbuildbot_ to be seen as not clean when checked from a `nextcloudci/node` container. To fix this version mismatch, and given that we have full control over `nextcloudci/node` but not over `node:lts`, _npmbuildbot_ should use `nextcloudci/node` instead.

Note that [server is using `nextcloudci/node:node-4`](https://github.com/nextcloud/server/blob/81d0b7079121103595fe352a95c5ac90865b4986/.drone.yml#L22-L35), which includes NPM 6.4.1, instead of `nextcloudci/node:node-7`, which includes nPM 6.12.0. However the built files are (or seem to be in a quick test :-) ) the same in both cases. For reference, besides having newer versions due to being built at a later time the only difference from `node-4` to `node-7` is that [`node-7` has the `make` command too](https://github.com/nextcloud/docker-ci/commit/4d09706218bbe51a06139eeba86690eade9d828d#diff-a6635e7a77e9b352875fd6ad78c91920).
